### PR TITLE
Settings Screen Re-Org; Adding More Settings

### DIFF
--- a/src/InteractiveSeven.Core/Settings/CommandSettings.cs
+++ b/src/InteractiveSeven.Core/Settings/CommandSettings.cs
@@ -192,7 +192,7 @@ namespace InteractiveSeven.Core.Settings
             }
         }
 
-        public string[] PaletteCommandWords // TODO: Add to Settings View
+        public string[] PaletteCommandWords
         {
             get => _paletteCommandWords;
             set
@@ -202,7 +202,7 @@ namespace InteractiveSeven.Core.Settings
             }
         }
 
-        public string[] RainbowCommandWords // TODO: Add to Settings View
+        public string[] RainbowCommandWords
         {
             get => _rainbowCommandWords;
             set
@@ -212,7 +212,7 @@ namespace InteractiveSeven.Core.Settings
             }
         }
 
-        public string[] MakoCommandWords // TODO: Add to Settings View
+        public string[] MakoCommandWords
         {
             get => _makoCommandWords;
             set
@@ -262,7 +262,7 @@ namespace InteractiveSeven.Core.Settings
             }
         }
 
-        public string[] MateriaCommandWords // TODO: Add to Settings Screen
+        public string[] MateriaCommandWords
         {
             get => _materiaCommandWords;
             set
@@ -272,7 +272,7 @@ namespace InteractiveSeven.Core.Settings
             }
         }
 
-        public string[] ItemCommandWords // TODO: Add to Settings Screen
+        public string[] ItemCommandWords
         {
             get => _itemCommandWords;
             set

--- a/src/InteractiveSeven.Core/Settings/MenuColorSettings.cs
+++ b/src/InteractiveSeven.Core/Settings/MenuColorSettings.cs
@@ -11,6 +11,7 @@
         private int _rainbowModeIterations = 30;
         private bool _enableMakoCommand = true;
         private int _makoModeCost = 500;
+        private int _makoModeIterations = 30;
         private bool _enablePaletteCommand = true;
         private bool _allowModsToCreatePalettes = true;
 
@@ -91,12 +92,22 @@
             }
         }
 
-        public int MakoModeCost // TODO: Add to Settings Screen
+        public int MakoModeCost
         {
             get => _makoModeCost;
             set
             {
                 _makoModeCost = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public int MakoModeIterations
+        {
+            get => _makoModeIterations;
+            set
+            {
+                _makoModeIterations = value;
                 OnPropertyChanged();
             }
         }

--- a/src/InteractiveSeven.Core/Settings/MenuColorSettings.cs
+++ b/src/InteractiveSeven.Core/Settings/MenuColorSettings.cs
@@ -8,6 +8,7 @@
         private bool _transitionColors = true;
         private bool _enableRainbowCommand = true;
         private int _rainbowModeCost = 1000;
+        private int _rainbowModeIterations = 30;
         private bool _enableMakoCommand = true;
         private int _makoModeCost = 500;
         private bool _enablePaletteCommand = true;
@@ -60,7 +61,7 @@
             }
         }
 
-        public int RainbowModeCost // TODO: Add to Settings Screen
+        public int RainbowModeCost
         {
             get => _rainbowModeCost;
             set
@@ -69,6 +70,17 @@
                 OnPropertyChanged();
             }
         }
+
+        public int RainbowModeIterations
+        {
+            get => _rainbowModeIterations;
+            set
+            {
+                _rainbowModeIterations = value;
+                OnPropertyChanged();
+            }
+        }
+
         public bool EnableMakoCommand
         {
             get => _enableMakoCommand;

--- a/src/InteractiveSeven.Core/Settings/TsengSettings.cs
+++ b/src/InteractiveSeven.Core/Settings/TsengSettings.cs
@@ -13,5 +13,16 @@
             }
         }
 
+        private int _portNumber = 7777;
+        public int PortNumber
+        {
+            get => _portNumber;
+            set
+            {
+                _portNumber = value;
+                OnPropertyChanged();
+            }
+        }
+
     }
 }

--- a/src/InteractiveSeven.Core/Workloads/MakoColorsWorkload.cs
+++ b/src/InteractiveSeven.Core/Workloads/MakoColorsWorkload.cs
@@ -12,6 +12,7 @@ namespace InteractiveSeven.Core.Workloads
     {
         private readonly IMenuColorAccessor _menuColorAccessor;
         private readonly ILogger<WorkloadCoordinator> _logger;
+        private ApplicationSettings Settings => ApplicationSettings.Instance;
 
         public MakoColorsWorkload(IMenuColorAccessor menuColorAccessor,
             ILogger<WorkloadCoordinator> logger)
@@ -56,7 +57,7 @@ namespace InteractiveSeven.Core.Workloads
         {
             try
             {
-                for (int i = 0; i < 10; i++)
+                for (int i = 0; i < Settings.MenuSettings.MakoModeIterations / MakoColors.Count + 1; i++)
                 {
                     foreach (MenuColors menuColors in MakoColors)
                     {

--- a/src/InteractiveSeven.Core/Workloads/RainbowWorkload.cs
+++ b/src/InteractiveSeven.Core/Workloads/RainbowWorkload.cs
@@ -10,6 +10,7 @@ namespace InteractiveSeven.Core.Workloads
     {
         private readonly IMenuColorAccessor _menuColorAccessor;
         private readonly ILogger<WorkloadCoordinator> _logger;
+        private ApplicationSettings Settings => ApplicationSettings.Instance;
 
         public RainbowWorkload(IMenuColorAccessor menuColorAccessor,
             ILogger<WorkloadCoordinator> logger)
@@ -22,7 +23,7 @@ namespace InteractiveSeven.Core.Workloads
         {
             try
             {
-                for (int i = 0; i < 100; i++) // TODO: Configurable Time
+                for (int i = 0; i < Settings.MenuSettings.RainbowModeIterations; i++)
                 {
                     _menuColorAccessor.SetMenuColors(ApplicationSettings.Instance.ProcessName,
                         MenuColors.RandomPalette());

--- a/src/InteractiveSeven/App.xaml.cs
+++ b/src/InteractiveSeven/App.xaml.cs
@@ -2,14 +2,14 @@
 using InteractiveSeven.Core.Settings;
 using InteractiveSeven.Core.Workloads;
 using InteractiveSeven.Startup;
+using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Serilog;
 using System;
 using System.Threading.Tasks;
 using System.Windows;
-using Microsoft.AspNetCore;
 using Tseng;
 
 namespace InteractiveSeven
@@ -23,6 +23,7 @@ namespace InteractiveSeven
 
         private IWebHost _host;
         private TsengProgram _tsengProgram;
+        private ILogger<App> _logger;
 
         private static void InitializeSettings()
         {
@@ -47,6 +48,8 @@ namespace InteractiveSeven
 
             _host.Start();
 
+            _logger = _host.Services.GetService<ILogger<App>>();
+
             var dataLoader = _host.Services.GetService<DataLoader>();
             dataLoader.LoadPreviousData();
 
@@ -54,13 +57,14 @@ namespace InteractiveSeven
 
             _tsengProgram = _host.Services.GetService<TsengProgram>();
 
-            Task.Run(() => _tsengProgram.Start()).RunInBackgroundSafely(false, LogError);
+            Task.Run(() => _tsengProgram.Start()).RunInBackgroundSafely(false, LogTsengError);
 
             _host.Services.GetRequiredService<MainWindow>().Show();
         }
 
-        private void LogError(Exception obj)
+        private void LogTsengError(Exception ex)
         {
+            _logger.LogError(ex, "Error in Tseng Status Overlay.");
         }
 
         private async void App_OnExit(object sender, ExitEventArgs e)

--- a/src/InteractiveSeven/MainWindow.xaml
+++ b/src/InteractiveSeven/MainWindow.xaml
@@ -441,112 +441,142 @@
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
 
                                         <Label Grid.Row="0" Grid.Column="0" Content="Costs Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="0" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="0" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=CostsCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="1" Grid.Column="0" Content="Balance Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="1" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="1" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=BalanceCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="2" Grid.Column="0" Content="Give Gil Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="2" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="2" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=GiveGilCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="3" Grid.Column="0" Content="I7 Mod Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="3" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="3" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=I7CommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="4" Grid.Column="0" Content="Menu Color Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="4" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="4" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=MenuCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="5" Grid.Column="0" Content="Name Bids Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="5" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="5" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=NameBidsCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="6" Grid.Column="0" Content="Refresh Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="6" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="6" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=RefreshCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="7" Grid.Column="0" Content="Help Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="7" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="7" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=HelpCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="8" Grid.Column="0" Content="Weapon Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="8" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="8" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=WeaponCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="9" Grid.Column="0" Content="Armlet Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="9" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="9" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=ArmletCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="10" Grid.Column="0" Content="Accessory Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="10" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="10" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=AccessoryCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="11" Grid.Column="0" Content="Pauper Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="11" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="11" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=PauperCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="12" Grid.Column="0" Content="Name Cloud Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="12" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="12" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=CloudCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="13" Grid.Column="0" Content="Name Barret Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="13" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="13" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=BarretCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="14" Grid.Column="0" Content="Name Tifa Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="14" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="14" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=TifaCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="15" Grid.Column="0" Content="Name Aeris Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="15" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="15" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=AerisCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="16" Grid.Column="0" Content="Name Cait Sith Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="16" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="16" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=CaitCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="17" Grid.Column="0" Content="Name Cid Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="17" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="17" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=CidCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="18" Grid.Column="0" Content="Name Red XIII Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="18" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="18" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=RedCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="19" Grid.Column="0" Content="Name Vincent Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="19" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="19" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=VincentCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
 
                                         <Label Grid.Row="20" Grid.Column="0" Content="Name Yuffie Command Words" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="20" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        <wpfTool:WatermarkTextBox Grid.Row="20" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
                                             Text="{Binding Path=YuffieCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
+
+                                        <Label Grid.Row="21" Grid.Column="0" Content="Mako Command Words" FontSize="12" Margin="5,10,0,0" />
+                                        <wpfTool:WatermarkTextBox Grid.Row="21" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
+                                            Text="{Binding Path=MakoCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
+
+                                        <Label Grid.Row="22" Grid.Column="0" Content="Rainbow Command Words" FontSize="12" Margin="5,10,0,0" />
+                                        <wpfTool:WatermarkTextBox Grid.Row="22" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
+                                            Text="{Binding Path=RainbowCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
+
+                                        <Label Grid.Row="23" Grid.Column="0" Content="Palette Command Words" FontSize="12" Margin="5,10,0,0" />
+                                        <wpfTool:WatermarkTextBox Grid.Row="23" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
+                                            Text="{Binding Path=PaletteCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
+
+                                        <Label Grid.Row="24" Grid.Column="0" Content="Materia Command Words" FontSize="12" Margin="5,10,0,0" />
+                                        <wpfTool:WatermarkTextBox Grid.Row="24" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
+                                            Text="{Binding Path=MateriaCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
+
+                                        <Label Grid.Row="25" Grid.Column="0" Content="Items Command Words" FontSize="12" Margin="5,10,0,0" />
+                                        <wpfTool:WatermarkTextBox Grid.Row="25" Grid.Column="1" VerticalContentAlignment="Center" HorizontalAlignment="Stretch"
+                                            Text="{Binding Path=ItemCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,10,0" />
                                     </Grid>
                                 </DockPanel>
                             </ScrollViewer>

--- a/src/InteractiveSeven/MainWindow.xaml
+++ b/src/InteractiveSeven/MainWindow.xaml
@@ -17,7 +17,7 @@
             </StackPanel>
             <Grid>
                 <Label Content="Interactive Seven" 
-                       VerticalAlignment="Center" HorizontalAlignment="Center" FontSize="20" />
+                       VerticalAlignment="Center" HorizontalAlignment="Left" FontSize="20" />
             </Grid>
         </DockPanel>
         <Grid DockPanel.Dock="Bottom" Height="50" Background="#666">
@@ -630,14 +630,56 @@
                         <TextBlock Text="About" />
                     </StackPanel>
                 </TabItem.Header>
-                <StackPanel>
-                    <Label Content="About Interactive Seven" FontWeight="Bold" FontSize="16" />
-                    <TextBlock TextWrapping="WrapWithOverflow" Margin="10 0 10 0">
-                        Interactive Seven is an application created by Brendan Enrick (@DevChatter) for use by Twitch 
-                        Streamers playing Final Fantasy 7. It is intended to help the streamers have more interaction with
-                        chat as well as allow them to earn some bits through command actions and bidding features.
-                    </TextBlock>
-                </StackPanel>
+                <ScrollViewer>
+                    <StackPanel>
+                        <Label Content="About Interactive Seven" FontWeight="Bold" FontSize="18" />
+                        <TextBlock TextWrapping="WrapWithOverflow" Margin="10 0 10 0">
+                            Interactive Seven is intended to help the streamers have more interaction with
+                            chat as well as allow them to earn some bits through command actions and bidding features.
+                        </TextBlock>
+                        <TextBlock TextWrapping="WrapWithOverflow" Margin="10 5 10 0">
+                            In addition, it includes the Tseng Party Status Overlay, which allows the streamer to display
+                            the current Status of their party in the game directly in their stream at all times.
+                        </TextBlock>
+                        <TextBlock TextWrapping="WrapWithOverflow" Margin="10 5 10 0">
+                            In July 2019, Brendan and Joshua learned about each other's project and decided it made sense to
+                            collaborate on a combined project, since both applications do similar work. This version of
+                            Interactive Seven includes the Tseng Overlay.
+                        </TextBlock>
+                        <Label Content="History of Interactive Seven" FontWeight="Bold" FontSize="16" />
+                        <TextBlock TextWrapping="WrapWithOverflow" Margin="10 0 10 0">
+                            The original Interactive Seven was created by Brendan Enrick as a way to give Twitch
+                            chat control over streamers' instances of Final Fantasy 7 while they stream the game.
+                        </TextBlock>
+                        <Label Content="History of Tseng Status Overlay" FontWeight="Bold" FontSize="16" />
+                        <TextBlock TextWrapping="WrapWithOverflow" Margin="10 0 10 0">
+                            The original Tseng Status Overlay was created by Joshua Moon, and
+                            allows streamers playing Final Fantasy 7 to show the party status while playing.
+                        </TextBlock>
+                        <Label Content="Primary Contributors" FontWeight="Bold" FontSize="14" />
+                        <WrapPanel HorizontalAlignment="Left" Orientation="Horizontal">
+                            <Border BorderBrush="Navy" BorderThickness="1" Padding="5 0 5 5" Margin="5">
+                                <StackPanel>
+                                    <Label Content="Brendan Enrick" FontWeight="Bold" FontSize="12" />
+                                    <StackPanel Margin="20 0 0 0">
+                                        <TextBlock Text="Twitter: @Brendoneus" />
+                                        <TextBlock Text="Twitch: @DevChatter" />
+                                        <TextBlock Text="GitHub: @benrick" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                            <Border BorderBrush="Navy" BorderThickness="1" Padding="5 0 5 5" Margin="5">
+                                <StackPanel>
+                                    <Label Content="Joshua Moon" FontWeight="Bold" FontSize="12" />
+                                    <StackPanel Margin="20 0 0 0">
+                                        <TextBlock Text="Twitch: @MrShojy" />
+                                        <TextBlock Text="GitHub: @shojy" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </WrapPanel>
+                    </StackPanel>
+                </ScrollViewer>
             </TabItem>
         </TabControl>
     </DockPanel>

--- a/src/InteractiveSeven/MainWindow.xaml
+++ b/src/InteractiveSeven/MainWindow.xaml
@@ -229,31 +229,29 @@
                                 </StackPanel>
                             </TabItem.Header>
                             <ScrollViewer>
-                                <DockPanel>
-                                    <Grid Margin="5,5,0,5">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="Auto" />
-                                            <RowDefinition Height="Auto" />
-                                        </Grid.RowDefinitions>
+                                <Grid Margin="5,5,0,5">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
 
-                                        <Label Grid.Row="0" Grid.Column="0" Content="Bot Username" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="0" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                            Text="{Binding Path=Username, Mode=TwoWay}" Watermark="Example: DevChatterBot" Margin="5,10,0,0" />
+                                    <Label Grid.Row="0" Grid.Column="0" Content="Bot Username" FontSize="12" Margin="5,10,0,0" />
+                                    <wpfTool:WatermarkTextBox Grid.Row="0" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        Text="{Binding Path=Username, Mode=TwoWay}" Watermark="Example: DevChatterBot" Margin="5,10,0,0" />
 
-                                        <Label Grid.Row="1" Grid.Column="0" Content="Access Token" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkPasswordBox Grid.Row="1" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                            PasswordChanged="AccessTokenTextBox_PasswordChanged" Watermark="Example: oauth:abcdefghijklmnopqrstuvwxyz" Margin="5,10,0,0" />
+                                    <Label Grid.Row="1" Grid.Column="0" Content="Access Token" FontSize="12" Margin="5,10,0,0" />
+                                    <wpfTool:WatermarkPasswordBox Grid.Row="1" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        PasswordChanged="AccessTokenTextBox_PasswordChanged" Watermark="Example: oauth:abcdefghijklmnopqrstuvwxyz" Margin="5,10,0,0" />
 
-                                        <Label Grid.Row="2" Grid.Column="0" Content="Twitch Channel" FontSize="12" Margin="5,10,0,0" />
-                                        <wpfTool:WatermarkTextBox Grid.Row="2" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                            Text="{Binding Path=Channel, Mode=TwoWay}" Watermark="Example: DevChatter" Margin="5,10,0,0" />
-                                    </Grid>
-                                </DockPanel>
+                                    <Label Grid.Row="2" Grid.Column="0" Content="Twitch Channel" FontSize="12" Margin="5,10,0,0" />
+                                    <wpfTool:WatermarkTextBox Grid.Row="2" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
+                                        Text="{Binding Path=Channel, Mode=TwoWay}" Watermark="Example: DevChatter" Margin="5,10,0,0" />
+                                </Grid>
                             </ScrollViewer>
                         </TabItem>
 
@@ -705,6 +703,33 @@
                                     </ItemsControl>
 
                                 </DockPanel>
+                            </ScrollViewer>
+                        </TabItem>
+
+
+                        <TabItem DataContext="{Binding TsengSettings}">
+                            <TabItem.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="Tseng" />
+                                </StackPanel>
+                            </TabItem.Header>
+                            <ScrollViewer>
+                                <Grid Margin="5,5,0,5">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
+
+                                    <wpfTool:IntegerUpDown Grid.Row="0" Grid.Column="0" Width="75" Minimum="0"
+                                                           Increment="10" Maximum="65535"
+                                                           Value="{Binding Path=PortNumber, Mode=TwoWay}" />
+                                    <Label Grid.Row="0" Grid.Column="1" Content="Port Number" FontSize="12" Margin="5,0,0,0" />
+                                </Grid>
                             </ScrollViewer>
                         </TabItem>
 

--- a/src/InteractiveSeven/MainWindow.xaml
+++ b/src/InteractiveSeven/MainWindow.xaml
@@ -619,22 +619,7 @@
                             </TabItem.Header>
                             <ScrollViewer>
                                 <DockPanel>
-                                    <ItemsControl IsEnabled="{Binding AllowStatusEffects}"
-                                                  DockPanel.Dock="Bottom" Margin="5,5,0,5"
-                                                  ItemsSource="{Binding AllStatusEffects}">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <WrapPanel Orientation="Horizontal" />
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <lc:StatusEffectSettings DataContext="{Binding}" Margin="2" />
-                                            </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>
-
-                                    <Grid HorizontalAlignment="Left" Margin="5,5,0,5">
+                                    <Grid DockPanel.Dock="Top" HorizontalAlignment="Left" Margin="5,5,0,5">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="*" />
                                             <ColumnDefinition Width="*" />
@@ -653,6 +638,21 @@
                                         <Label Grid.Row="1" Grid.Column="1" VerticalContentAlignment="Center" Content="Allow Mod Override" FontSize="12" Margin="5,0,0,0"/>
 
                                     </Grid>
+
+                                    <ItemsControl IsEnabled="{Binding AllowStatusEffects}"
+                                                  Margin="5,5,0,5"
+                                                  ItemsSource="{Binding AllStatusEffects}">
+                                        <ItemsControl.ItemsPanel>
+                                            <ItemsPanelTemplate>
+                                                <WrapPanel Orientation="Horizontal" />
+                                            </ItemsPanelTemplate>
+                                        </ItemsControl.ItemsPanel>
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <lc:StatusEffectSettings DataContext="{Binding}" Margin="2" />
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
 
                                 </DockPanel>
                             </ScrollViewer>

--- a/src/InteractiveSeven/MainWindow.xaml
+++ b/src/InteractiveSeven/MainWindow.xaml
@@ -183,7 +183,6 @@
                             </TabItem.Header>
                             <ScrollViewer>
                                 <DockPanel>
-                                    <TextBlock Text="General Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
                                     <Grid Margin="5,5,0,5">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
@@ -231,7 +230,6 @@
                             </TabItem.Header>
                             <ScrollViewer>
                                 <DockPanel>
-                                    <TextBlock Text="Twitch Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
                                     <Grid Margin="5,5,0,5">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
@@ -268,7 +266,6 @@
                             </TabItem.Header>
                             <ScrollViewer>
                                 <DockPanel>
-                                    <TextBlock Text="Menu Color Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
                                     <Grid Margin="5,5,0,5">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
@@ -331,7 +328,6 @@
                             </TabItem.Header>
                             <ScrollViewer>
                                 <DockPanel>
-                                    <TextBlock Text="Name Bidding Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
                                     <Grid Margin="5,5,0,5">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
@@ -418,7 +414,6 @@
                             </TabItem.Header>
                             <ScrollViewer>
                                 <DockPanel>
-                                    <TextBlock Text="Command Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
                                     <Grid Margin="5,5,0,5">
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="Auto" />
@@ -566,7 +561,6 @@
                             </TabItem.Header>
                             <ScrollViewer>
                                 <DockPanel>
-                                    <TextBlock Text="Equipment Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
 
                                     <!--<ItemsControl IsEnabled="{Binding Enabled}"
                                               DockPanel.Dock="Bottom" Margin="5,5,0,5"
@@ -625,7 +619,6 @@
                             </TabItem.Header>
                             <ScrollViewer>
                                 <DockPanel>
-                                    <TextBlock Text="Status Effect Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
                                     <ItemsControl IsEnabled="{Binding AllowStatusEffects}"
                                                   DockPanel.Dock="Bottom" Margin="5,5,0,5"
                                                   ItemsSource="{Binding AllStatusEffects}">

--- a/src/InteractiveSeven/MainWindow.xaml
+++ b/src/InteractiveSeven/MainWindow.xaml
@@ -282,6 +282,8 @@
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
 
                                         <CheckBox Grid.Row="0" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
@@ -301,28 +303,36 @@
                                         <Label Grid.Row="3" Grid.Column="1" Content="Minimum Bits Required" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="4" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                        IsChecked="{Binding Path=EnableMakoCommand, Mode=TwoWay}" />
-                                        <Label Grid.Row="4" Grid.Column="1" Content="Enable Mako Mode" FontSize="12" Margin="5,0,0,0" />
+                                        IsChecked="{Binding Path=EnablePaletteCommand, Mode=TwoWay}" />
+                                        <Label Grid.Row="4" Grid.Column="1" Content="Enable Palette Command" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="5" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                        IsChecked="{Binding Path=EnablePaletteCommand, Mode=TwoWay}" />
-                                        <Label Grid.Row="5" Grid.Column="1" Content="Enable Palette Command" FontSize="12" Margin="5,0,0,0" />
+                                        IsEnabled="{Binding EnablePaletteCommand}" IsChecked="{Binding Path=AllowModsToCreatePalettes, Mode=TwoWay}" />
+                                        <Label Grid.Row="5" Grid.Column="1" Content="Allow Mods to Create Palettes" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="6" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                        IsEnabled="{Binding EnablePaletteCommand}" IsChecked="{Binding Path=AllowModsToCreatePalettes, Mode=TwoWay}" />
-                                        <Label Grid.Row="6" Grid.Column="1" Content="Allow Mods to Create Palettes" FontSize="12" Margin="5,0,0,0" />
-
-                                        <CheckBox Grid.Row="7" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
                                                   IsChecked="{Binding Path=EnableRainbowCommand, Mode=TwoWay}" />
-                                        <Label Grid.Row="7" Grid.Column="1" Content="Enable Rainbow Mode" FontSize="12" Margin="5,0,0,0" />
+                                        <Label Grid.Row="6" Grid.Column="1" Content="Enable Rainbow Mode" FontSize="12" Margin="5,0,0,0" />
+
+                                        <wpfTool:IntegerUpDown Grid.Row="7" Grid.Column="0" Width="75" Minimum="0" Increment="10" FormatString="N0"
+                                                               IsEnabled="{Binding EnableRainbowCommand}" Value="{Binding Path=RainbowModeCost, Mode=TwoWay}" />
+                                        <Label Grid.Row="7" Grid.Column="1" Content="Rainbow Mode Cost" FontSize="12" Margin="5,0,0,0" />
 
                                         <wpfTool:IntegerUpDown Grid.Row="8" Grid.Column="0" Width="75" Minimum="0" Increment="10" FormatString="N0"
-                                                               IsEnabled="{Binding EnableRainbowCommand}" Value="{Binding Path=RainbowModeCost, Mode=TwoWay}" />
-                                        <Label Grid.Row="8" Grid.Column="1" Content="Rainbow Mode Cost" FontSize="12" Margin="5,0,0,0" />
-
-                                        <wpfTool:IntegerUpDown Grid.Row="9" Grid.Column="0" Width="75" Minimum="0" Increment="10" FormatString="N0"
                                                                IsEnabled="{Binding EnableRainbowCommand}" Value="{Binding Path=RainbowModeIterations, Mode=TwoWay}" />
-                                        <Label Grid.Row="9" Grid.Column="1" Content="Rainbow Mode Iterations" FontSize="12" Margin="5,0,0,0" />
+                                        <Label Grid.Row="8" Grid.Column="1" Content="Rainbow Mode Iterations" FontSize="12" Margin="5,0,0,0" />
+
+                                        <CheckBox Grid.Row="9" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
+                                                  IsChecked="{Binding Path=EnableMakoCommand, Mode=TwoWay}" />
+                                        <Label Grid.Row="9" Grid.Column="1" Content="Enable Mako Mode" FontSize="12" Margin="5,0,0,0" />
+
+                                        <wpfTool:IntegerUpDown Grid.Row="10" Grid.Column="0" Width="75" Minimum="0" Increment="10" FormatString="N0"
+                                                               IsEnabled="{Binding EnableMakoCommand}" Value="{Binding Path=MakoModeCost, Mode=TwoWay}" />
+                                        <Label Grid.Row="10" Grid.Column="1" Content="Mako Mode Cost" FontSize="12" Margin="5,0,0,0" />
+
+                                        <wpfTool:IntegerUpDown Grid.Row="11" Grid.Column="0" Width="75" Minimum="0" Increment="10" FormatString="N0"
+                                                               IsEnabled="{Binding EnableMakoCommand}" Value="{Binding Path=MakoModeIterations, Mode=TwoWay}" />
+                                        <Label Grid.Row="11" Grid.Column="1" Content="Mako Mode Iterations" FontSize="12" Margin="5,0,0,0" />
 
                                     </Grid>
                                 </DockPanel>

--- a/src/InteractiveSeven/MainWindow.xaml
+++ b/src/InteractiveSeven/MainWindow.xaml
@@ -728,7 +728,12 @@
                                     <wpfTool:IntegerUpDown Grid.Row="0" Grid.Column="0" Width="75" Minimum="0"
                                                            Increment="10" Maximum="65535"
                                                            Value="{Binding Path=PortNumber, Mode=TwoWay}" />
-                                    <Label Grid.Row="0" Grid.Column="1" Content="Port Number" FontSize="12" Margin="5,0,0,0" />
+                                    <Label Grid.Row="0" Grid.Column="1" Content="Port Number *requires restart to take effect" FontSize="12" Margin="5,0,0,0" />
+
+                                    <wpfTool:IntegerUpDown Grid.Row="1" Grid.Column="0" Width="75" Minimum="100"
+                                                           Increment="10" Maximum="600000"
+                                                           Value="{Binding Path=MemoryReadIntervalInMs, Mode=TwoWay}" />
+                                    <Label Grid.Row="1" Grid.Column="1" Content="Basic Memory Read Interval in MS" FontSize="12" Margin="5,0,0,0" />
                                 </Grid>
                             </ScrollViewer>
                         </TabItem>

--- a/src/InteractiveSeven/MainWindow.xaml
+++ b/src/InteractiveSeven/MainWindow.xaml
@@ -343,7 +343,7 @@
                         <TabItem DataContext="{Binding NameBiddingSettings}">
                             <TabItem.Header>
                                 <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="Menu Color" />
+                                    <TextBlock Text="Name Bidding" />
                                 </StackPanel>
                             </TabItem.Header>
                             <ScrollViewer>

--- a/src/InteractiveSeven/MainWindow.xaml
+++ b/src/InteractiveSeven/MainWindow.xaml
@@ -165,19 +165,24 @@
                         <TextBlock Text="Settings" />
                     </StackPanel>
                 </TabItem.Header>
-                <ScrollViewer>
-                    <DockPanel Background="#FFE5E5E5">
-                        <StackPanel HorizontalAlignment="Center" DockPanel.Dock="Top" Orientation="Horizontal">
-                            <Button Content="Save Settings" Command="{Binding Path=SaveSettingsCommand}"
+                <DockPanel Background="#FFE5E5E5">
+                    <StackPanel HorizontalAlignment="Center" DockPanel.Dock="Top" Orientation="Horizontal">
+                        <Button Content="Save Settings" Command="{Binding Path=SaveSettingsCommand}"
                                         Width="150" Padding="0,10,0,10" Margin="0,10,30,10" />
-                            <Button Content="Load Settings" Command="{Binding Path=LoadSettingsCommand}"
+                        <Button Content="Load Settings" Command="{Binding Path=LoadSettingsCommand}"
                                         Width="150" Padding="0,10,0,10" Margin="30,10,0,10" />
-                        </StackPanel>
-                        <WrapPanel Orientation="Horizontal" DataContext="{Binding Settings}">
+                    </StackPanel>
+                    <TabControl DataContext="{Binding Settings}">
 
 
-                            <Border BorderThickness="1" BorderBrush="Black" Margin="5">
-                                <DockPanel Width="500">
+                        <TabItem DataContext="{Binding}">
+                            <TabItem.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="General" />
+                                </StackPanel>
+                            </TabItem.Header>
+                            <ScrollViewer>
+                                <DockPanel>
                                     <TextBlock Text="General Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
                                     <Grid Margin="5,5,0,5">
                                         <Grid.ColumnDefinitions>
@@ -214,11 +219,18 @@
 
                                     </Grid>
                                 </DockPanel>
-                            </Border>
+                            </ScrollViewer>
+                        </TabItem>
 
 
-                            <Border DataContext="{Binding TwitchSettings}" BorderThickness="1" BorderBrush="Black" Margin="5">
-                                <DockPanel Width="500">
+                        <TabItem DataContext="{Binding TwitchSettings}">
+                            <TabItem.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="Twitch" />
+                                </StackPanel>
+                            </TabItem.Header>
+                            <ScrollViewer>
+                                <DockPanel>
                                     <TextBlock Text="Twitch Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
                                     <Grid Margin="5,5,0,5">
                                         <Grid.ColumnDefinitions>
@@ -233,22 +245,29 @@
 
                                         <Label Grid.Row="0" Grid.Column="0" Content="Bot Username" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="0" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=Username, Mode=TwoWay}" Watermark="Example: DevChatterBot" Margin="5,10,0,0" />
+                                            Text="{Binding Path=Username, Mode=TwoWay}" Watermark="Example: DevChatterBot" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="1" Grid.Column="0" Content="Access Token" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkPasswordBox Grid.Row="1" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                PasswordChanged="AccessTokenTextBox_PasswordChanged" Watermark="Example: oauth:abcdefghijklmnopqrstuvwxyz" Margin="5,10,0,0" />
+                                            PasswordChanged="AccessTokenTextBox_PasswordChanged" Watermark="Example: oauth:abcdefghijklmnopqrstuvwxyz" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="2" Grid.Column="0" Content="Twitch Channel" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="2" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=Channel, Mode=TwoWay}" Watermark="Example: DevChatter" Margin="5,10,0,0" />
+                                            Text="{Binding Path=Channel, Mode=TwoWay}" Watermark="Example: DevChatter" Margin="5,10,0,0" />
                                     </Grid>
                                 </DockPanel>
-                            </Border>
+                            </ScrollViewer>
+                        </TabItem>
 
 
-                            <Border DataContext="{Binding MenuSettings}" BorderThickness="1" BorderBrush="Black" Margin="5">
-                                <DockPanel Width="500">
+                        <TabItem DataContext="{Binding MenuSettings}">
+                            <TabItem.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="Menu Color" />
+                                </StackPanel>
+                            </TabItem.Header>
+                            <ScrollViewer>
+                                <DockPanel>
                                     <TextBlock Text="Menu Color Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
                                     <Grid Margin="5,5,0,5">
                                         <Grid.ColumnDefinitions>
@@ -267,44 +286,51 @@
                                         </Grid.RowDefinitions>
 
                                         <CheckBox Grid.Row="0" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                            IsChecked="{Binding Path=Enabled, Mode=TwoWay}" />
+                                        IsChecked="{Binding Path=Enabled, Mode=TwoWay}" />
                                         <Label Grid.Row="0" Grid.Column="1" Content="Enable Menu Color Command" FontSize="12" Margin="5,0,0,0"/>
 
                                         <CheckBox Grid.Row="1" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                            IsEnabled="{Binding Enabled}" IsChecked="{Binding Path=AllowModOverride, Mode=TwoWay}" />
+                                        IsEnabled="{Binding Enabled}" IsChecked="{Binding Path=AllowModOverride, Mode=TwoWay}" />
                                         <Label Grid.Row="1" Grid.Column="1" Content="Allow Mod Override" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="2" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                            IsEnabled="{Binding Enabled}" IsChecked="{Binding Path=TransitionColors, Mode=TwoWay}" />
+                                        IsEnabled="{Binding Enabled}" IsChecked="{Binding Path=TransitionColors, Mode=TwoWay}" />
                                         <Label Grid.Row="2" Grid.Column="1" Content="Smooth Color Transitions (instead of isntant change)" FontSize="12" Margin="5,0,0,0" />
 
                                         <wpfTool:IntegerUpDown Grid.Row="3" Grid.Column="0" Width="75" Minimum="0" Increment="10" FormatString="N0"
-                                                               IsEnabled="{Binding Enabled}" Value="{Binding Path=BitCost, Mode=TwoWay}" />
+                                                           IsEnabled="{Binding Enabled}" Value="{Binding Path=BitCost, Mode=TwoWay}" />
                                         <Label Grid.Row="3" Grid.Column="1" Content="Minimum Bits Required" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="4" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                            IsChecked="{Binding Path=EnableRainbowCommand, Mode=TwoWay}" />
+                                        IsChecked="{Binding Path=EnableRainbowCommand, Mode=TwoWay}" />
                                         <Label Grid.Row="4" Grid.Column="1" Content="Enable Rainbow Mode" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="5" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                            IsChecked="{Binding Path=EnableMakoCommand, Mode=TwoWay}" />
+                                        IsChecked="{Binding Path=EnableMakoCommand, Mode=TwoWay}" />
                                         <Label Grid.Row="5" Grid.Column="1" Content="Enable Mako Mode" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="6" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                            IsChecked="{Binding Path=EnablePaletteCommand, Mode=TwoWay}" />
+                                        IsChecked="{Binding Path=EnablePaletteCommand, Mode=TwoWay}" />
                                         <Label Grid.Row="6" Grid.Column="1" Content="Enable Palette Command" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="7" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                            IsEnabled="{Binding EnablePaletteCommand}" IsChecked="{Binding Path=AllowModsToCreatePalettes, Mode=TwoWay}" />
+                                        IsEnabled="{Binding EnablePaletteCommand}" IsChecked="{Binding Path=AllowModsToCreatePalettes, Mode=TwoWay}" />
                                         <Label Grid.Row="7" Grid.Column="1" Content="Allow Mods to Create Palettes" FontSize="12" Margin="5,0,0,0" />
 
                                     </Grid>
                                 </DockPanel>
-                            </Border>
+                            </ScrollViewer>
+                        </TabItem>
 
 
-                            <Border DataContext="{Binding NameBiddingSettings}" BorderThickness="1" BorderBrush="Black" Margin="5">
-                                <DockPanel Width="500">
+                        <TabItem DataContext="{Binding NameBiddingSettings}">
+                            <TabItem.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="Menu Color" />
+                                </StackPanel>
+                            </TabItem.Header>
+                            <ScrollViewer>
+                                <DockPanel>
                                     <TextBlock Text="Name Bidding Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
                                     <Grid Margin="5,5,0,5">
                                         <Grid.ColumnDefinitions>
@@ -328,63 +354,70 @@
                                         </Grid.RowDefinitions>
 
                                         <CheckBox Grid.Row="0" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                                IsChecked="{Binding Path=Enabled, Mode=TwoWay}" />
+                                            IsChecked="{Binding Path=Enabled, Mode=TwoWay}" />
                                         <Label Grid.Row="0" Grid.Column="1" Content="Enable Naming Commands" FontSize="12" Margin="5,0,0,0"/>
 
                                         <wpfTool:IntegerUpDown Grid.Row="1" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                                Value="{Binding Path=DefaultStartBits, Mode=TwoWay}"  Width="50" Minimum="0" Increment="10" FormatString="N0" />
+                                            Value="{Binding Path=DefaultStartBits, Mode=TwoWay}"  Width="50" Minimum="0" Increment="10" FormatString="N0" />
                                         <Label Grid.Row="1" Grid.Column="1" Content="Default Name Starting Bits" FontSize="12" Margin="5,0,0,0"/>
 
                                         <CheckBox Grid.Row="2" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                                IsChecked="{Binding Path=AllowModeration, Mode=TwoWay}" />
+                                            IsChecked="{Binding Path=AllowModeration, Mode=TwoWay}" />
                                         <Label Grid.Row="2" Grid.Column="1" Content="Enable Moderation of Names" FontSize="12" Margin="5,0,0,0"/>
 
                                         <CheckBox Grid.Row="3" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                                IsChecked="{Binding Path=AllowModBits, Mode=TwoWay}" />
+                                            IsChecked="{Binding Path=AllowModBits, Mode=TwoWay}" />
                                         <Label Grid.Row="3" Grid.Column="1" Content="Enable Mod Override - Free Bits" FontSize="12" Margin="5,0,0,0"/>
 
                                         <CheckBox Grid.Row="4" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                              IsChecked="{Binding Path=NamingCloudEnabled, Mode=TwoWay}" />
+                                          IsChecked="{Binding Path=NamingCloudEnabled, Mode=TwoWay}" />
                                         <Label Grid.Row="4" Grid.Column="1" Content="Allow Naming Cloud" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="5" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                              IsChecked="{Binding Path=NamingBarretEnabled, Mode=TwoWay}" />
+                                          IsChecked="{Binding Path=NamingBarretEnabled, Mode=TwoWay}" />
                                         <Label Grid.Row="5" Grid.Column="1" Content="Allow Naming Barret" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="6" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                              IsChecked="{Binding Path=NamingTifaEnabled, Mode=TwoWay}" />
+                                          IsChecked="{Binding Path=NamingTifaEnabled, Mode=TwoWay}" />
                                         <Label Grid.Row="6" Grid.Column="1" Content="Allow Naming Tifa" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="7" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                              IsChecked="{Binding Path=NamingAerisEnabled, Mode=TwoWay}" />
+                                          IsChecked="{Binding Path=NamingAerisEnabled, Mode=TwoWay}" />
                                         <Label Grid.Row="7" Grid.Column="1" Content="Allow Naming Aeris" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="8" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                              IsChecked="{Binding Path=NamingCaitSithEnabled, Mode=TwoWay}" />
+                                          IsChecked="{Binding Path=NamingCaitSithEnabled, Mode=TwoWay}" />
                                         <Label Grid.Row="8" Grid.Column="1" Content="Allow Naming Cait Sith" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="9" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                              IsChecked="{Binding Path=NamingCidEnabled, Mode=TwoWay}" />
+                                          IsChecked="{Binding Path=NamingCidEnabled, Mode=TwoWay}" />
                                         <Label Grid.Row="9" Grid.Column="1" Content="Allow Naming Cid" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="10" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                              IsChecked="{Binding Path=NamingRedEnabled, Mode=TwoWay}" />
+                                          IsChecked="{Binding Path=NamingRedEnabled, Mode=TwoWay}" />
                                         <Label Grid.Row="10" Grid.Column="1" Content="Allow Naming Red XIII" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="11" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                              IsChecked="{Binding Path=NamingVincentEnabled, Mode=TwoWay}" />
+                                          IsChecked="{Binding Path=NamingVincentEnabled, Mode=TwoWay}" />
                                         <Label Grid.Row="11" Grid.Column="1" Content="Allow Naming Vincent" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="12" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                              IsChecked="{Binding Path=NamingYuffieEnabled, Mode=TwoWay}" />
+                                          IsChecked="{Binding Path=NamingYuffieEnabled, Mode=TwoWay}" />
                                         <Label Grid.Row="12" Grid.Column="1" Content="Allow Naming Yuffie" FontSize="12" Margin="5,0,0,0" />
                                     </Grid>
                                 </DockPanel>
-                            </Border>
+                            </ScrollViewer>
+                        </TabItem>
 
 
-                            <Border DataContext="{Binding CommandSettings}" BorderThickness="1" BorderBrush="Black" Margin="5">
-                                <DockPanel Width="500">
+                        <TabItem DataContext="{Binding CommandSettings}">
+                            <TabItem.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="Command" />
+                                </StackPanel>
+                            </TabItem.Header>
+                            <ScrollViewer>
+                                <DockPanel>
                                     <TextBlock Text="Command Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
                                     <Grid Margin="5,5,0,5">
                                         <Grid.ColumnDefinitions>
@@ -417,131 +450,138 @@
 
                                         <Label Grid.Row="0" Grid.Column="0" Content="Costs Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="0" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=CostsCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=CostsCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="1" Grid.Column="0" Content="Balance Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="1" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=BalanceCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=BalanceCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="2" Grid.Column="0" Content="Give Gil Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="2" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=GiveGilCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=GiveGilCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="3" Grid.Column="0" Content="I7 Mod Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="3" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=I7CommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=I7CommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="4" Grid.Column="0" Content="Menu Color Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="4" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=MenuCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=MenuCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="5" Grid.Column="0" Content="Name Bids Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="5" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=NameBidsCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=NameBidsCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="6" Grid.Column="0" Content="Refresh Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="6" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=RefreshCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=RefreshCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="7" Grid.Column="0" Content="Help Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="7" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=HelpCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=HelpCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="8" Grid.Column="0" Content="Weapon Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="8" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=WeaponCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=WeaponCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="9" Grid.Column="0" Content="Armlet Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="9" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=ArmletCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=ArmletCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="10" Grid.Column="0" Content="Accessory Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="10" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=AccessoryCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=AccessoryCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="11" Grid.Column="0" Content="Pauper Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="11" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=PauperCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=PauperCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="12" Grid.Column="0" Content="Name Cloud Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="12" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=CloudCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=CloudCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="13" Grid.Column="0" Content="Name Barret Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="13" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=BarretCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=BarretCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="14" Grid.Column="0" Content="Name Tifa Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="14" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=TifaCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=TifaCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="15" Grid.Column="0" Content="Name Aeris Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="15" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=AerisCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=AerisCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="16" Grid.Column="0" Content="Name Cait Sith Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="16" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=CaitCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=CaitCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="17" Grid.Column="0" Content="Name Cid Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="17" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=CidCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=CidCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="18" Grid.Column="0" Content="Name Red XIII Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="18" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=RedCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=RedCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="19" Grid.Column="0" Content="Name Vincent Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="19" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=VincentCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=VincentCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
 
                                         <Label Grid.Row="20" Grid.Column="0" Content="Name Yuffie Command Words" FontSize="12" Margin="5,10,0,0" />
                                         <wpfTool:WatermarkTextBox Grid.Row="20" Grid.Column="1" Width="300" VerticalContentAlignment="Center" HorizontalAlignment="Left"
-                                                Text="{Binding Path=YuffieCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
-                                                Watermark="Add words separated by commas" Margin="5,10,0,0" />
+                                            Text="{Binding Path=YuffieCommandWords, Mode=TwoWay, Converter={StaticResource CommandWordsValueConverter}}"
+                                            Watermark="Add words separated by commas" Margin="5,10,0,0" />
                                     </Grid>
                                 </DockPanel>
-                            </Border>
+                            </ScrollViewer>
+                        </TabItem>
 
 
-                            <Border DataContext="{Binding EquipmentSettings}"  BorderThickness="1" BorderBrush="Black" Margin="5">
-                                <DockPanel Width="500">
+                        <TabItem DataContext="{Binding EquipmentSettings}">
+                            <TabItem.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="Equipment" />
+                                </StackPanel>
+                            </TabItem.Header>
+                            <ScrollViewer>
+                                <DockPanel>
                                     <TextBlock Text="Equipment Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
 
                                     <!--<ItemsControl IsEnabled="{Binding Enabled}"
-                                                  DockPanel.Dock="Bottom" Margin="5,5,0,5"
-                                                  ItemsSource="{Binding AllWeapons}">
-                                        <ItemsControl.ItemsPanel>
-                                            <ItemsPanelTemplate>
-                                                <WrapPanel Orientation="Horizontal" />
-                                            </ItemsPanelTemplate>
-                                        </ItemsControl.ItemsPanel>
-                                        <ItemsControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <lc:EquippableSettingsUc DataContext="{Binding}" Margin="2" />
-                                            </DataTemplate>
-                                        </ItemsControl.ItemTemplate>
-                                    </ItemsControl>-->
+                                              DockPanel.Dock="Bottom" Margin="5,5,0,5"
+                                              ItemsSource="{Binding AllWeapons}">
+                                    <ItemsControl.ItemsPanel>
+                                        <ItemsPanelTemplate>
+                                            <WrapPanel Orientation="Horizontal" />
+                                        </ItemsPanelTemplate>
+                                    </ItemsControl.ItemsPanel>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <lc:EquippableSettingsUc DataContext="{Binding}" Margin="2" />
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>-->
 
 
                                     <Grid Margin="5,5,0,5">
@@ -557,31 +597,38 @@
                                         </Grid.RowDefinitions>
 
                                         <CheckBox Grid.Row="0" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                                  IsChecked="{Binding Path=Enabled, Mode=TwoWay}" />
+                                              IsChecked="{Binding Path=Enabled, Mode=TwoWay}" />
                                         <Label Grid.Row="0" Grid.Column="1" Content="Enable Equipment Commands" FontSize="12" Margin="5,0,0,0"/>
 
                                         <CheckBox Grid.Row="1" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                                  IsEnabled="{Binding Enabled}" IsChecked="{Binding Path=AllowModOverride, Mode=TwoWay}" />
+                                              IsEnabled="{Binding Enabled}" IsChecked="{Binding Path=AllowModOverride, Mode=TwoWay}" />
                                         <Label Grid.Row="1" Grid.Column="1" Content="Allow Moderator Override" FontSize="12" Margin="5,0,0,0"/>
 
                                         <CheckBox Grid.Row="2" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                                  IsEnabled="{Binding Enabled}" IsChecked="{Binding Path=KeepPreviousEquipment, Mode=TwoWay}" />
+                                              IsEnabled="{Binding Enabled}" IsChecked="{Binding Path=KeepPreviousEquipment, Mode=TwoWay}" />
                                         <Label Grid.Row="2" Grid.Column="1" Content="Keep Previous Equipment" FontSize="12" Margin="5,0,0,0"/>
 
                                         <CheckBox Grid.Row="3" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                                  IsEnabled="{Binding Enabled}" IsChecked="{Binding Path=EnablePauperCommand, Mode=TwoWay}" />
+                                              IsEnabled="{Binding Enabled}" IsChecked="{Binding Path=EnablePauperCommand, Mode=TwoWay}" />
                                         <Label Grid.Row="3" Grid.Column="1" Content="Enable Pauper Command (lose all equipment, items, materia, and gil)" FontSize="12" Margin="5,0,0,0"/>
                                     </Grid>
                                 </DockPanel>
-                            </Border>
+                            </ScrollViewer>
+                        </TabItem>
 
 
-                            <Border DataContext="{Binding BattleSettings}" BorderThickness="1" BorderBrush="Black" Margin="5">
-                                <DockPanel Width="500">
+                        <TabItem DataContext="{Binding BattleSettings}">
+                            <TabItem.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="Status Effects" />
+                                </StackPanel>
+                            </TabItem.Header>
+                            <ScrollViewer>
+                                <DockPanel>
                                     <TextBlock Text="Status Effect Settings" DockPanel.Dock="Top" HorizontalAlignment="Center" FontSize="14" FontWeight="Bold" />
                                     <ItemsControl IsEnabled="{Binding AllowStatusEffects}"
-                                                      DockPanel.Dock="Bottom" Margin="5,5,0,5"
-                                                      ItemsSource="{Binding AllStatusEffects}">
+                                                  DockPanel.Dock="Bottom" Margin="5,5,0,5"
+                                                  ItemsSource="{Binding AllStatusEffects}">
                                         <ItemsControl.ItemsPanel>
                                             <ItemsPanelTemplate>
                                                 <WrapPanel Orientation="Horizontal" />
@@ -605,22 +652,22 @@
                                         </Grid.RowDefinitions>
 
                                         <CheckBox Grid.Row="0" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                                      IsChecked="{Binding Path=AllowStatusEffects, Mode=TwoWay}" />
+                                                  IsChecked="{Binding Path=AllowStatusEffects, Mode=TwoWay}" />
                                         <Label Grid.Row="0" Grid.Column="1" VerticalContentAlignment="Center" Content="Enable Status Effect Commands" FontSize="12" Margin="5,0,0,0"/>
 
                                         <CheckBox Grid.Row="1" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                                      IsChecked="{Binding Path=AllowModOverride, Mode=TwoWay}" IsEnabled="{Binding AllowStatusEffects}" />
+                                                  IsChecked="{Binding Path=AllowModOverride, Mode=TwoWay}" IsEnabled="{Binding AllowStatusEffects}" />
                                         <Label Grid.Row="1" Grid.Column="1" VerticalContentAlignment="Center" Content="Allow Mod Override" FontSize="12" Margin="5,0,0,0"/>
 
                                     </Grid>
 
                                 </DockPanel>
-                            </Border>
+                            </ScrollViewer>
+                        </TabItem>
 
 
-                        </WrapPanel>
-                    </DockPanel>
-                </ScrollViewer>
+                    </TabControl>
+                </DockPanel>
             </TabItem>
 
             <TabItem>

--- a/src/InteractiveSeven/MainWindow.xaml
+++ b/src/InteractiveSeven/MainWindow.xaml
@@ -280,6 +280,8 @@
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
 
                                         <CheckBox Grid.Row="0" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
@@ -299,20 +301,28 @@
                                         <Label Grid.Row="3" Grid.Column="1" Content="Minimum Bits Required" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="4" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                        IsChecked="{Binding Path=EnableRainbowCommand, Mode=TwoWay}" />
-                                        <Label Grid.Row="4" Grid.Column="1" Content="Enable Rainbow Mode" FontSize="12" Margin="5,0,0,0" />
+                                        IsChecked="{Binding Path=EnableMakoCommand, Mode=TwoWay}" />
+                                        <Label Grid.Row="4" Grid.Column="1" Content="Enable Mako Mode" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="5" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                        IsChecked="{Binding Path=EnableMakoCommand, Mode=TwoWay}" />
-                                        <Label Grid.Row="5" Grid.Column="1" Content="Enable Mako Mode" FontSize="12" Margin="5,0,0,0" />
+                                        IsChecked="{Binding Path=EnablePaletteCommand, Mode=TwoWay}" />
+                                        <Label Grid.Row="5" Grid.Column="1" Content="Enable Palette Command" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="6" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                        IsChecked="{Binding Path=EnablePaletteCommand, Mode=TwoWay}" />
-                                        <Label Grid.Row="6" Grid.Column="1" Content="Enable Palette Command" FontSize="12" Margin="5,0,0,0" />
+                                        IsEnabled="{Binding EnablePaletteCommand}" IsChecked="{Binding Path=AllowModsToCreatePalettes, Mode=TwoWay}" />
+                                        <Label Grid.Row="6" Grid.Column="1" Content="Allow Mods to Create Palettes" FontSize="12" Margin="5,0,0,0" />
 
                                         <CheckBox Grid.Row="7" Grid.Column="0" VerticalContentAlignment="Center" HorizontalAlignment="Right"
-                                        IsEnabled="{Binding EnablePaletteCommand}" IsChecked="{Binding Path=AllowModsToCreatePalettes, Mode=TwoWay}" />
-                                        <Label Grid.Row="7" Grid.Column="1" Content="Allow Mods to Create Palettes" FontSize="12" Margin="5,0,0,0" />
+                                                  IsChecked="{Binding Path=EnableRainbowCommand, Mode=TwoWay}" />
+                                        <Label Grid.Row="7" Grid.Column="1" Content="Enable Rainbow Mode" FontSize="12" Margin="5,0,0,0" />
+
+                                        <wpfTool:IntegerUpDown Grid.Row="8" Grid.Column="0" Width="75" Minimum="0" Increment="10" FormatString="N0"
+                                                               IsEnabled="{Binding EnableRainbowCommand}" Value="{Binding Path=RainbowModeCost, Mode=TwoWay}" />
+                                        <Label Grid.Row="8" Grid.Column="1" Content="Rainbow Mode Cost" FontSize="12" Margin="5,0,0,0" />
+
+                                        <wpfTool:IntegerUpDown Grid.Row="9" Grid.Column="0" Width="75" Minimum="0" Increment="10" FormatString="N0"
+                                                               IsEnabled="{Binding EnableRainbowCommand}" Value="{Binding Path=RainbowModeIterations, Mode=TwoWay}" />
+                                        <Label Grid.Row="9" Grid.Column="1" Content="Rainbow Mode Iterations" FontSize="12" Margin="5,0,0,0" />
 
                                     </Grid>
                                 </DockPanel>


### PR DESCRIPTION
Live streamed on August 3, 2019 starting around 18:00 UTC.

Changed the settings screen to be tabbed instead of grouped. Also added settings for Mako mode, Rainbow mode, and a few other things.